### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/XiaoLabJHU/GRN_Inference/security/code-scanning/1](https://github.com/XiaoLabJHU/GRN_Inference/security/code-scanning/1)

The best way to fix the problem is to explicitly set the required permissions using the `permissions` key in the workflow file. Since the workflow only requires read access to repository contents (for actions like checking out code), you should add a `permissions: contents: read` block. This can be done at the root of the workflow file (so it applies to all jobs), or under the `build` job if only that job exists. Here, as there is only one job, you can safely add it at the workflow root just after the `name` key for clarity and maintainability.

**Edit:**  
- In `.github/workflows/python-package.yml`, after the `name: Python package` line (typically line 4), insert the following block:
  ```yaml
  permissions:
    contents: read
  ```
No extra imports or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
